### PR TITLE
search for text and attribute content in record search XPath

### DIFF
--- a/src/main/java/org/opengis/cite/cat30/ETSAssert.java
+++ b/src/main/java/org/opengis/cite/cat30/ETSAssert.java
@@ -314,8 +314,8 @@ public class ETSAssert {
         for (String term : searchTerms) {
             for (int i = 0; i < recordList.getLength(); i++) {
                 Element record = (Element) recordList.item(i);
-                // case-insensitive match of text content in all child elements
-                String expr = String.format("child::*[matches(., '%s', 'i')]", term);
+                // case-insensitive match of text and attribute content in all child elements
+                String expr = String.format("child::*[matches(., '%s', 'i')]|child::*/attribute::*[matches(., '%s', 'i')]", term, term);
                 try {
                     XdmValue result = XMLUtils.evaluateXPath2(
                             new DOMSource(record), expr, null);


### PR DESCRIPTION
# Overview

This PR adds attribute content to record searches.

# Rationale

[Atom](https://tools.ietf.org/html/rfc4287#section-4.2.2) says that `atom:category` has no text content but a `term` attribute.  Example:

```xml
<!-- not this -->
<atom:category>Land</atom:category>
<!-- this -->
<atom:category term="Land"/>
```
For reference, the underlying matching
record is as per https://github.com/geopython/pycsw/blob/master/tests/suites/cite/data/Record_e9330592-0932-474b-be34-c3a3bb67c7db.xml

# Test Assertions

This issue manifests itself in the following test failure:

```xml
        <test-method status="FAIL" signature="multipleKeywordSearch()[pri:0, instance:org.opengis.cite.cat30.opensearch.OpenSearchCoreTests@11ad78c]" name="multipleKeywordSearch" duration-ms="746" started-at="2015-06-28T18:27:18Z" description="OGC 12-176, Table 6: Text search" finished-at="2015-06-28T18:27:19Z">
          <exception class="java.lang.AssertionError">
            <message>
              <![CDATA[Unexpected result evaluating XPath expression with context node atom:entry[urn:uuid:e9330592-0932-474b-be34-c3a3bb67c7db]: child::*[matches(., 'Land', 'i')] expected [true] but found [false]]]>
            </message>
```

Here, the test invokes `http://example.org/csw?service=CSW&version=3.0.0&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&q=Fuscé%20Land&bbox=&time=/&outputformat=application/atom+xml&&startposition=1&maxrecords=&recordids=`

and then attempts to search for evidence of the text `Land` in the search result.  Given `Land` is displayed as an XML attribute, the XPath test is expanded per subject to realize a passing assertion.