### PR TITLE
Set maven-fluido-skin to version 2.0.1

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.5</version>
+    <version>2.0.1</version>
   </skin>
   <custom>
     <fluidoSkin>


### PR DESCRIPTION
Fix maven-fluido-skin version, context in https://github.com/opengeospatial/cite-private/issues/395.